### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # EZSwipeController
 
-[![Cocoapods Compatible](https://img.shields.io/cocoapods/v/EZSwipeController.svg)](https://img.shields.io/cocoapods/v/EZSwipeController.svg)  
+[![CocoaPods Compatible](https://img.shields.io/cocoapods/v/EZSwipeController.svg)](https://img.shields.io/cocoapods/v/EZSwipeController.svg)  
 
 Easy to use UIPageViewController to create a view navigation like Snapchat/Tinder/iOS Main Pages.
 
@@ -13,7 +13,7 @@ Easy to use UIPageViewController to create a view navigation like Snapchat/Tinde
 
 ## Install via CocoaPods (~10 seconds)
 
-You can use [Cocoapods](http://cocoapods.org/) to install `EZSwipeController` by adding it to your `Podfile`:
+You can use [CocoaPods](http://cocoapods.org/) to install `EZSwipeController` by adding it to your `Podfile`:
 
 ```ruby
 platform :ios, '8.0'
@@ -60,7 +60,7 @@ func application(application: UIApplication, didFinishLaunchingWithOptions launc
 
 ``` swift
 import UIKit
-// import EZSwipeController // if using Cocoapods
+// import EZSwipeController // if using CocoaPods
 class MySwipeVC: EZSwipeController {
     override func setupView() {
         datasource = self


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
