### PR TITLE
Fix sizing if opened during call

### DIFF
--- a/EZSwipeController.swift
+++ b/EZSwipeController.swift
@@ -145,8 +145,14 @@ open class EZSwipeController: UIViewController {
         stackPageVC = [UIViewController]()
         stackVC.enumerated().forEach { index, viewController in
             let pageViewController = UIViewController()
+            viewController.view.frame = pageViewController.view.bounds
+            viewController.view.autoresizingMask = [
+                .flexibleWidth,
+                .flexibleHeight
+            ]
             if !navigationBarShouldBeOnBottom && !navigationBarShouldNotExist {
                 viewController.view.frame.origin.y += Constants.navigationBarHeight
+                viewController.view.frame.size.height -= Constants.navigationBarHeight
             }
             pageViewController.addChildViewController(viewController)
             pageViewController.view.addSubview(viewController.view)

--- a/EZSwipeController/AppDelegate.swift
+++ b/EZSwipeController/AppDelegate.swift
@@ -13,8 +13,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
 
-
-    private func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey : Any]? = nil) -> Bool {
         // Override point for customization after application launch.
         window = UIWindow(frame: UIScreen.main.bounds)
         window!.rootViewController = MySwipeVC()

--- a/EZSwipeController/MySwipeVC.swift
+++ b/EZSwipeController/MySwipeVC.swift
@@ -37,6 +37,20 @@ extension MySwipeVC: EZSwipeControllerDataSource {
         testButton.backgroundColor = UIColor.green
         testButton.addTarget(self, action: #selector(MySwipeVC.moveToEnd), for: UIControlEvents.touchUpInside)
         redVC.view.addSubview(testButton)
+      
+        let label = UILabel()
+        label.text = "Test view bottom"
+        label.sizeToFit()
+        label.center = CGPoint(
+          x: redVC.view.bounds.width / 2,
+          y: redVC.view.bounds.height - label.frame.size.height
+        )
+        label.autoresizingMask = [
+          .flexibleTopMargin,
+          .flexibleLeftMargin,
+          .flexibleRightMargin
+        ]
+        redVC.view.addSubview(label)
         
         let blueVC = UIViewController()
         blueVC.view.backgroundColor = UIColor.blue


### PR DESCRIPTION
Steps to reproduce fixed issue:
 - Start the app with opened call (big, green status bar)
 - Stop the call

Expected:
 - App opens with smaller size and grows, when call stopped and status bar shrinks

Before:
 - App opens with wrong size and shifted down and when call stopped, the view is still shifted by 20 px.